### PR TITLE
Fixed proxying pages with encoding other than utf-8

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -5,6 +5,7 @@ const converter = require('rel-to-abs');
 const fs = require('fs');
 const index = fs.readFileSync('index.html', 'utf8');
 const ResponseBuilder = require('./app/ResponseBuilder');
+const Iconv = require('iconv').Iconv;
 
 module.exports = function(app){
     app.get('/*', (req, res) => {
@@ -26,9 +27,21 @@ module.exports = function(app){
             resolveWithFullResponse: true,
             headers: {
                 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36'
-            }
+            },
+            encoding: null
         })
         .then(originResponse => {            
+            let charset;
+            if (originResponse.headers['content-type']) {
+                if (originResponse.headers["content-type"].match(/charset=(.*)/) &&
+                    originResponse.headers["content-type"].match(/charset=(.*)/)[1]) {
+                    charset = originResponse.headers["content-type"].match(/charset=(.*)/)[1]
+                }
+                if (charset) {
+                    const conv = new Iconv(charset, 'utf-8');
+                    originResponse.body = conv.convert(originResponse.body).toString();
+                }
+            }
             responseBuilder
                 .addHeaderByKeyValue('Access-Control-Allow-Origin', '*')
                 .addHeaderByKeyValue('Access-Control-Allow-Credentials', false)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nock": "^7.2.2",
     "rel-to-abs": "^0.1.0",
     "request-promise": "^2.0.0",
-    "supertest": "^1.2.0"
+    "supertest": "^1.2.0",
+    "iconv": "2.3.1"
   }
 }


### PR DESCRIPTION
Jacob, thank you for sharing great tool!
Take a look at my PR, that fixes broken encoding when trying to proxy pages with encoding other than utf-8.
You can reproduce problem by querying http://localhost:3000/https://newtimes.ru/rubrics/ as example.