### PR TITLE
Preserve query string in proxied URL

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -10,11 +10,10 @@ module.exports = function(app){
     app.get('/*', (req, res) => {
         const responseBuilder = new ResponseBuilder(res);
         
-        const origionalUrl = req.originalUrl;
-        const requestedUrl = req.params[0];
+        const requestedUrl = req.url.slice(1);
         const corsBaseUrl = '//' + req.get('host');
         
-        console.info(req.protocol + '://' + req.get('host') + origionalUrl);
+        console.info(req.protocol + '://' + req.get('host') + req.url);
         
         if(requestedUrl == ''){
             res.send(index);


### PR DESCRIPTION
This PR fixes a bug where query string parameters in the requested URL are not passed through to the proxied URL.

There are a few failing tests but I get the same results testing on `master`. It appears to be failing due to a domain that no longer exists.

Resolves #2 